### PR TITLE
Bug fix with Boomer interp_type parameter

### DIFF
--- a/src/solvers/testHelpers/SolverTestParameters.cpp
+++ b/src/solvers/testHelpers/SolverTestParameters.cpp
@@ -187,7 +187,7 @@ std::unique_ptr<AMP::Database> SolverParameters::getBoomerAMGParameters( bool us
     db->putScalar<int>( "min_coarse_size", 10 );
     db->putScalar<int>( "relax_type", 16 );
     db->putScalar<int>( "coarsen_type", 10 );
-    db->putScalar<int>( "inter_type", 17 );
+    db->putScalar<int>( "interp_type", 17 );
     db->putScalar<int>( "cycle_type", 1 );
     db->putScalar<int>( "relax_order", 0 );
     db->putScalar<double>( "strong_threshold", 0.5 );


### PR DESCRIPTION
Updated Database key in getBoomerAMGParameters() of src/solvers/testHelpers/SolverTestParameters.cpp from "inter_type" to "interp_type" to make consistent with the expected key in src/solvers/hypre/BoomerAMGSolver.cpp